### PR TITLE
Handling corner-case of burned token UTXOs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "GPL-2.0",
       "dependencies": {
         "@chris.troutner/slp-validate": "1.2.2",
-        "@psf/bch-js": "5.4.0",
+        "@psf/bch-js": "6.2.1",
         "@psf/bitcoincash-zmq-decoder": "0.1.5",
         "axios": "0.21.1",
         "bcryptjs": "2.4.3",
@@ -1457,16 +1457,16 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "node_modules/@psf/bch-js": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-5.4.0.tgz",
-      "integrity": "sha512-HyBCpobC9moxSbQl4k/tb/GW9p8L12Fu+8yR1x8eflxBe7c2bwBlG218LmuoNcvjJMAdDxk0VEHvtO64vpltsw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-6.2.1.tgz",
+      "integrity": "sha512-sTqjbPkpfxrxu0WARZBf/t2K+Sz3Y4EpuzHlSZG2n4k7jKM+J8tQuh/stRsEXOl/ewwdVmjNIAcBx+Z+MkCtHQ==",
       "dependencies": {
         "@chris.troutner/bip32-utils": "1.0.5",
         "@psf/bip21": "2.0.1",
         "@psf/bitcoincash-ops": "2.0.0",
         "@psf/bitcoincashjs-lib": "4.0.2",
         "@psf/coininfo": "4.0.0",
-        "axios": "^0.21.4",
+        "axios": "0.26.1",
         "bc-bip68": "1.0.5",
         "bchaddrjs-slp": "0.2.5",
         "bigi": "1.4.2",
@@ -1488,11 +1488,11 @@
       }
     },
     "node_modules/@psf/bch-js/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.8"
       }
     },
     "node_modules/@psf/bch-js/node_modules/bignumber.js": {
@@ -6325,21 +6325,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "node_modules/fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -12758,20 +12743,6 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
-      }
-    },
-    "node_modules/nodemon/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/nodemon/node_modules/has-flag": {
@@ -22483,16 +22454,16 @@
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@psf/bch-js": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-5.4.0.tgz",
-      "integrity": "sha512-HyBCpobC9moxSbQl4k/tb/GW9p8L12Fu+8yR1x8eflxBe7c2bwBlG218LmuoNcvjJMAdDxk0VEHvtO64vpltsw==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/@psf/bch-js/-/bch-js-6.2.1.tgz",
+      "integrity": "sha512-sTqjbPkpfxrxu0WARZBf/t2K+Sz3Y4EpuzHlSZG2n4k7jKM+J8tQuh/stRsEXOl/ewwdVmjNIAcBx+Z+MkCtHQ==",
       "requires": {
         "@chris.troutner/bip32-utils": "1.0.5",
         "@psf/bip21": "2.0.1",
         "@psf/bitcoincash-ops": "2.0.0",
         "@psf/bitcoincashjs-lib": "4.0.2",
         "@psf/coininfo": "4.0.0",
-        "axios": "^0.21.4",
+        "axios": "0.26.1",
         "bc-bip68": "1.0.5",
         "bchaddrjs-slp": "0.2.5",
         "bigi": "1.4.2",
@@ -22514,11 +22485,11 @@
       },
       "dependencies": {
         "axios": {
-          "version": "0.21.4",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "version": "0.26.1",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+          "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
           "requires": {
-            "follow-redirects": "^1.14.0"
+            "follow-redirects": "^1.14.8"
           }
         },
         "bignumber.js": {
@@ -26454,13 +26425,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
-    },
-    "fsevents": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
-      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -31665,13 +31629,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "fsevents": {
-          "version": "2.3.2",
-          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-          "dev": true,
-          "optional": true
         },
         "has-flag": {
           "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "repository": "Permissionless-Software-Foundation/psf-slp-indexer",
   "dependencies": {
     "@chris.troutner/slp-validate": "1.2.2",
-    "@psf/bch-js": "5.4.0",
+    "@psf/bch-js": "6.2.1",
     "@psf/bitcoincash-zmq-decoder": "0.1.5",
     "axios": "0.21.1",
     "bcryptjs": "2.4.3",

--- a/src/adapters/ipfs/ipfs.js
+++ b/src/adapters/ipfs/ipfs.js
@@ -103,9 +103,9 @@ class IpfsAdapter {
       console.error('Error in ipfs.js/start()')
 
       // If IPFS crashes because the /blocks directory is full, wipe the directory.
-      if (err.message.includes('No space left on device')) {
-        this.rmBlocksDir()
-      }
+      // if (err.message.includes('No space left on device')) {
+      //   this.rmBlocksDir()
+      // }
 
       throw err
     }
@@ -121,21 +121,21 @@ class IpfsAdapter {
   // Dev Note: It's assumed this node is not pinning any data and that
   // everything in this directory is transient. This folder will regularly
   // fill up and prevent IPFS from starting.
-  rmBlocksDir () {
-    try {
-      const dir = `${IPFS_DIR}/blocks`
-      console.log(`Deleting ${dir} directory...`)
-
-      this.fs.rmdirSync(dir, { recursive: true })
-
-      console.log(`${dir} directory is deleted!`)
-
-      return true // Signal successful execution.
-    } catch (err) {
-      console.log('Error in rmBlocksDir()')
-      throw err
-    }
-  }
+  // rmBlocksDir () {
+  //  try {
+  //    const dir = `${IPFS_DIR}/blocks`
+  //    console.log(`Deleting ${dir} directory...`)
+  //
+  //    this.fs.rmdirSync(dir, { recursive: true })
+  //
+  //    console.log(`${dir} directory is deleted!`)
+  //
+  //    return true // Signal successful execution.
+  //  } catch (err) {
+  //    console.log('Error in rmBlocksDir()')
+  //    throw err
+  //  }
+  // }
 }
 
 module.exports = IpfsAdapter

--- a/src/adapters/slp-indexer/index.js
+++ b/src/adapters/slp-indexer/index.js
@@ -295,10 +295,11 @@ class SlpIndexer {
       const slpTxs = filteredTxs.combined
       const nonSlpTxs = filteredTxs.nonSlpTxs
       // console.log(`slpTxs: ${JSON.stringify(slpTxs, null, 2)}`)
-      console.log(`slpTxs: ${slpTxs.length}`)
 
       // If the block has no txs after filtering for SLP txs, then return.
-      if (!slpTxs.length) return
+      if (!slpTxs || !slpTxs.length) return
+
+      console.log(`slpTxs: ${slpTxs.length}`)
 
       // Progressively processes TXs in the array.
       await this.processSlpTxs(slpTxs, blockHeight)

--- a/src/adapters/slp-indexer/index.js
+++ b/src/adapters/slp-indexer/index.js
@@ -139,11 +139,11 @@ class SlpIndexer {
 
         blockHeight++
         biggestBlockHeight = await this.rpc.getBlockCount()
-      // } while (blockHeight <= biggestBlockHeight)
+      } while (blockHeight <= biggestBlockHeight)
       // } while (blockHeight < 638340)
-      } while (blockHeight < 688826)
-      console.log('Target block height reached.')
-      process.exit(0)
+      // } while (blockHeight < 688826)
+      // console.log('Target block height reached.')
+      // process.exit(0)
 
       // Debugging: state the current state of the indexer.
       console.log(`Leaving ${this.indexState}`)

--- a/src/adapters/slp-indexer/index.js
+++ b/src/adapters/slp-indexer/index.js
@@ -139,11 +139,11 @@ class SlpIndexer {
 
         blockHeight++
         biggestBlockHeight = await this.rpc.getBlockCount()
-      } while (blockHeight <= biggestBlockHeight)
+      // } while (blockHeight <= biggestBlockHeight)
       // } while (blockHeight < 638340)
-      // } while (blockHeight < 638338)
-      // console.log('Target block height reached.')
-      // process.exit(0)
+      } while (blockHeight < 688826)
+      console.log('Target block height reached.')
+      process.exit(0)
 
       // Debugging: state the current state of the indexer.
       console.log(`Leaving ${this.indexState}`)

--- a/src/adapters/slp-indexer/lib/dag.js
+++ b/src/adapters/slp-indexer/lib/dag.js
@@ -59,8 +59,10 @@ class DAG {
       }
 
       if (txidAry.length > 50) {
-        // console.log(`Large DAG detected: ${JSON.stringify(txidAry, null, 2)}`)
-        console.log(`Large DAG detected: ${txidAry.length} txs`)
+        if (txidAry.length % 10 === 0) {
+          // console.log(`Large DAG detected: ${JSON.stringify(txidAry, null, 2)}`)
+          console.log(`Large DAG detected: ${txidAry.length} txs`)
+        }
       }
 
       // If this is the genesis TX, then exit immediately.

--- a/src/adapters/slp-indexer/lib/filter-block.js
+++ b/src/adapters/slp-indexer/lib/filter-block.js
@@ -112,6 +112,7 @@ class FilterBlock {
   async filterSlpTxs (txids) {
     try {
       const slpTxs = []
+      // const nonSlpTxs = []
 
       // Add Tx to slpTxs array if it passes the OP_RETURN check.
       // This function is used below with the queue.
@@ -122,6 +123,9 @@ class FilterBlock {
         if (isSlp) {
           slpTxs.push(txid)
         } else {
+          // TODO:
+          // nonSlpTxs.push(txid)
+
           // Check if any input UTXOs are in the database. If so, delete them,
           // since they are officially burned.
           const result = await this.deleteBurnedUtxos(txid)

--- a/src/adapters/slp-indexer/lib/filter-block.js
+++ b/src/adapters/slp-indexer/lib/filter-block.js
@@ -112,7 +112,7 @@ class FilterBlock {
   async filterSlpTxs (txids) {
     try {
       const slpTxs = []
-      // const nonSlpTxs = []
+      const nonSlpTxs = []
 
       // Add Tx to slpTxs array if it passes the OP_RETURN check.
       // This function is used below with the queue.
@@ -124,7 +124,7 @@ class FilterBlock {
           slpTxs.push(txid)
         } else {
           // TODO:
-          // nonSlpTxs.push(txid)
+          nonSlpTxs.push(txid)
 
           // Check if any input UTXOs are in the database. If so, delete them,
           // since they are officially burned.
@@ -163,7 +163,7 @@ class FilterBlock {
       // This should be redundent.
       await this.pQueue.onEmpty()
 
-      return slpTxs
+      return { slpTxs, nonSlpTxs }
     } catch (err) {
       console.error('Error in filterSlpTxs()')
       throw err
@@ -493,7 +493,7 @@ class FilterBlock {
       console.log(`txids before filtering: ${txids.length}`)
 
       // Filter out all the non-SLP transactions.
-      let slpTxs = await this.filterSlpTxs(txids)
+      let { slpTxs, nonSlpTxs } = await this.filterSlpTxs(txids)
       console.log(`txs in slpTxs prior to sorting: ${slpTxs.length}`)
       // console.log(`slpTxs prior to sorting: ${JSON.stringify(slpTxs, null, 2)}`)
 
@@ -584,6 +584,7 @@ class FilterBlock {
       // console.log(`sortedTxids: ${JSON.stringify(sortedTxids, null, 2)}`)
       console.log(`independentTxids: ${independentTxids.length}`)
       console.log(`sortedTxids: ${sortedTxids.length}`)
+      console.log(`nonSlpTxs: ${nonSlpTxs.length}`)
 
       // Combine arrays with the independent txids first.
       let combined = independentTxids.concat(sortedTxids)
@@ -592,7 +593,7 @@ class FilterBlock {
       // https://stackoverflow.com/questions/9229645/remove-duplicate-values-from-js-array
       combined = [...new Set(combined)]
 
-      return combined
+      return { combined, nonSlpTxs }
     } catch (err) {
       console.error('Error in fitlerAndSortSlpTxs2()')
       // console.log(err)

--- a/src/adapters/slp-indexer/lib/utils.js
+++ b/src/adapters/slp-indexer/lib/utils.js
@@ -115,7 +115,7 @@ class IndexerUtils {
   // Subtract a burned UTXO balance from the token data tracking that quantity.
   subtractBurnedTokens (utxoObj, tokenData) {
     try {
-      console.log(`utxoObj: ${JSON.stringify(utxoObj, null, 2)}`)
+      // console.log(`utxoObj: ${JSON.stringify(utxoObj, null, 2)}`)
 
       // Skip if this is a minting baton. No quantities to subtract.
       if (utxoObj.type === 'baton') {

--- a/test/unit/adapters/ipfs.adapter.unit.js
+++ b/test/unit/adapters/ipfs.adapter.unit.js
@@ -4,10 +4,11 @@
 
 const assert = require('chai').assert
 const sinon = require('sinon')
-
 const IPFSLib = require('../../../src/adapters/ipfs/ipfs')
 const IPFSMock = require('../mocks/ipfs-mock')
+const config = require('../../../config')
 
+// config.isProduction =  true;
 describe('#IPFS-adapter', () => {
   let uut
   let sandbox
@@ -18,13 +19,45 @@ describe('#IPFS-adapter', () => {
     sandbox = sinon.createSandbox()
   })
 
-  afterEach(() => sandbox.restore())
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('#constructor', () => {
+    it('should instantiate IPFS Lib in dev mode.', async () => {
+      const _uut = new IPFSLib()
+      assert.exists(_uut)
+      assert.isFunction(_uut.start)
+      assert.isFunction(_uut.stop)
+    })
+
+    it('should instantiate dev IPFS Lib in production mode.', async () => {
+      config.isProduction = true
+      const _uut = new IPFSLib()
+      assert.exists(_uut)
+      assert.isFunction(_uut.start)
+      assert.isFunction(_uut.stop)
+      config.isProduction = false
+    })
+  })
 
   describe('#start', () => {
     it('should return a promise that resolves into an instance of IPFS.', async () => {
       // Mock dependencies.
       uut.IPFS = IPFSMock
 
+      const result = await uut.start()
+      // console.log('result: ', result)
+
+      assert.equal(uut.isReady, true)
+
+      assert.property(result, 'config')
+    })
+
+    it('should return a promise that resolves into an instance of IPFS in production mode.', async () => {
+      // Mock dependencies.
+      uut.IPFS = IPFSMock
+      uut.config.isProduction = true
       const result = await uut.start()
       // console.log('result: ', result)
 

--- a/test/unit/adapters/slp-indexer/lib/filter-block.unit.js
+++ b/test/unit/adapters/slp-indexer/lib/filter-block.unit.js
@@ -239,10 +239,11 @@ describe('#filter-block.js', () => {
         .resolves(true)
       sandbox.stub(uut, 'deleteBurnedUtxos').resolves(true)
 
-      const slpTxs = await uut.filterSlpTxs(txs)
+      const { slpTxs, nonSlpTxs } = await uut.filterSlpTxs(txs)
       // console.log(slpTxs)
 
       assert.isArray(slpTxs)
+      assert.isArray(nonSlpTxs)
       assert.equal(slpTxs.length, 1)
       assert.equal(slpTxs[0], txs[4])
     })
@@ -382,7 +383,7 @@ describe('#filter-block.js', () => {
       ]
 
       // Mock dependencies
-      sandbox.stub(uut, 'filterSlpTxs').resolves(txs)
+      sandbox.stub(uut, 'filterSlpTxs').resolves({ slpTxs: txs, nonSlpTxs: [] })
       sandbox
         .stub(uut, 'checkForParent2')
         .onCall(0)
@@ -398,12 +399,13 @@ describe('#filter-block.js', () => {
           unsortedArray: [txs[1]]
         })
 
-      const result = await uut.filterAndSortSlpTxs2(txs, blockHeight)
+      const { combined, nonSlpTxs } = await uut.filterAndSortSlpTxs2(txs, blockHeight)
       // console.log(`result: ${JSON.stringify(result, null, 2)}`)
 
-      assert.equal(result.length, 3)
-      assert.include(result[0], '82a9') // Independent tx
-      assert.include(result[2], 'e5ff') // newest chained tx
+      assert.equal(combined.length, 3)
+      assert.include(combined[0], '82a9') // Independent tx
+      assert.include(combined[2], 'e5ff') // newest chained tx
+      assert.isArray(nonSlpTxs)
     })
 
     it('should return an empty array if given an empty array', async () => {

--- a/util/index/getOneAddr.js
+++ b/util/index/getOneAddr.js
@@ -3,7 +3,7 @@
 */
 
 // const addr = 'bitcoincash:qq59p3sway2l5gxkv0dezf57xn4t85d2lyaa2jptwx'
-let addr = 'bitcoincash:qz90rpanj52tvwu8wqs8cyf7f48a95wgf5y9u3uvq2'
+let addr = 'bitcoincash:qrnn49rx0p4xh78tts79utf0zv26vyru6vqtl9trd3'
 
 const level = require('level')
 const BCHJS = require('@psf/bch-js')


### PR DESCRIPTION
This fixes a corner case where an SLP token is burned in the same block as its parent TX. The UTXO is spent, but it's data is not deleted from the psf-slp-indexer `addr` database.