### PR TITLE
fix(send): Fixing partial UTXO inflation bug

### DIFF
--- a/src/adapters/slp-indexer/index.js
+++ b/src/adapters/slp-indexer/index.js
@@ -141,7 +141,7 @@ class SlpIndexer {
         biggestBlockHeight = await this.rpc.getBlockCount()
       } while (blockHeight <= biggestBlockHeight)
       // } while (blockHeight < 638340)
-      // } while (blockHeight < 688826)
+      // } while (blockHeight < 738971)
       // console.log('Target block height reached.')
       // process.exit(0)
 

--- a/src/adapters/slp-indexer/tx-types/send.js
+++ b/src/adapters/slp-indexer/tx-types/send.js
@@ -210,6 +210,8 @@ class Send {
       } else if (diffBN.isLessThan(0)) {
         console.log('Outputs exceed inputs. Uncontrolled burn detected.')
         console.log(`${spentBN} tokens burned.`)
+        // console.log(`data: ${JSON.stringify(data, null, 2)}`)
+
         // Outputs exceed inputs, which make this an invalide TX, resulting in
         // burn of all tokens. All changes made by addTokensFromOutput() need
         // to be rolled back.
@@ -276,6 +278,13 @@ class Send {
         // Subtract the token balance
         const negAmntBN = await this.subtractBalanceFromSend(addrData, utxoToDelete[0])
         // console.log(`netAmntBN: ${negAmntBN.toString()}`)
+
+        // Delete the burned UTXO
+        addrData.utxos = this.util.removeUtxoFromArray(
+          utxoToDelete[0],
+          addrData.utxos
+        )
+        // console.log('addrData after utxo delete: ', addrData)
 
         // Track the total quantity of burned tokens.
         totalBurnedBN = totalBurnedBN.plus(negAmntBN)

--- a/util/index/getOneAddr.js
+++ b/util/index/getOneAddr.js
@@ -2,8 +2,8 @@
   Utility tool to retrieve a single TX from the TX database.
 */
 
-// const addr = 'bitcoincash:qq59p3sway2l5gxkv0dezf57xn4t85d2lyaa2jptwx'
-let addr = 'bitcoincash:qrnn49rx0p4xh78tts79utf0zv26vyru6vqtl9trd3'
+let addr = 'bitcoincash:qp5zflad4y9vk7q7m7l4j4cqtnvxkl7nh5y79lprka'
+// let addr = 'bitcoincash:qqwmwye0udasr7m92nxx6attxhramh5qj5xg3ejk49'
 
 const level = require('level')
 const BCHJS = require('@psf/bch-js')

--- a/util/index/getOneTx.js
+++ b/util/index/getOneTx.js
@@ -2,7 +2,7 @@
   Utility tool to retrieve a single TX from the TX database.
 */
 
-const TXID = '9b6db26b64aedcedc0bd9a3037b29b3598573ec5cea99eec03faa838616cd683'
+const TXID = '221b297f3c2d0421b8f12b70e44dc3ee72f205c84a5112c7fe5c6d7931b8ee50'
 // const TXID = '6d68a7ffbb63ef851c43025f801a1d365cddda50b00741bca022c743d74cd61a'
 
 const level = require('level')


### PR DESCRIPTION
This PR fixes a slight inflation bug. When the outputs exceed the inputs in an SLP token transaction, the entire transaction is considered invalid and the tokens are burned, as per the SLP specification. This rule was being followed in terms of calculating address balances. But the burned UTXO was not being deleted, so some wallets could have included the burned tokens in their calculations. This PR deletes the burned UTXO, in addition to the existing behavior which deducted burned tokens from the token balance.